### PR TITLE
test(backend): fix flaky SQLite race (duplicate column name: claimed_at)

### DIFF
--- a/Codebase/Backend/src/__tests__/coursePlannerService.test.ts
+++ b/Codebase/Backend/src/__tests__/coursePlannerService.test.ts
@@ -4,7 +4,7 @@ import os from 'os';
 import path from 'path';
 
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neoterritory-planner-'));
-const dbPath = path.join(tmpRoot, 'planner.sqlite');
+const dbPath = path.join(tmpRoot, 'coursePlannerService.sqlite');
 
 const aiMocks = vi.hoisted(() => ({
   pickProvider: vi.fn(),
@@ -19,7 +19,7 @@ vi.mock('../db/_testSeed/devconUsers', () => ({
   ensureTestFolders: () => {},
 }));
 
-import { generateCoursePlan } from '../services/coursePlannerService';
+let generateCoursePlan: (typeof import('../services/coursePlannerService'))['generateCoursePlan'];
 
 const devconStudentPrompt = [
   'Devcon student module delegation needs one stable enrollment flow, but onboarding, practice, check-ins, and certification can vary by cohort.',
@@ -52,6 +52,8 @@ describe('Course planner validation', () => {
     process.env.DB_PATH = dbPath;
     const { initDb } = await import('../db/initDb');
     initDb();
+
+    ({ generateCoursePlan } = await import('../services/coursePlannerService'));
   });
 
   beforeEach(() => {

--- a/Codebase/Backend/src/__tests__/projectLearningOrchestration.test.ts
+++ b/Codebase/Backend/src/__tests__/projectLearningOrchestration.test.ts
@@ -2,26 +2,31 @@ import { describe, it, expect, beforeAll, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import type { ProjectBriefInput } from '../services/projectLearningContracts';
 
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neoterritory-orch-'));
-const dbPath = path.join(tmpRoot, 'orch.sqlite');
+const dbPath = path.join(tmpRoot, 'projectLearningOrchestration.sqlite');
 
 vi.mock('../db/_testSeed/devconUsers', () => ({
   seedDevconUsers: () => {},
   ensureTestFolders: () => {},
 }));
 
-import * as intakeService from '../services/projectSpecIntakeService';
-import * as policyService from '../services/featureTogglePolicyService';
-import * as assessmentService from '../services/assessmentOrchestrationService';
-import { PATTERN_CATALOG } from '../services/coursePlannerService';
-import { ProjectBriefInput } from '../services/projectLearningContracts';
+let intakeService: typeof import('../services/projectSpecIntakeService');
+let policyService: typeof import('../services/featureTogglePolicyService');
+let assessmentService: typeof import('../services/assessmentOrchestrationService');
+let PATTERN_CATALOG: (typeof import('../services/coursePlannerService'))['PATTERN_CATALOG'];
 
 describe('Project Learning Orchestration Flow', () => {
   beforeAll(async () => {
     process.env.DB_PATH = dbPath;
     const { initDb } = await import('../db/initDb');
     initDb();
+
+    intakeService = await import('../services/projectSpecIntakeService');
+    policyService = await import('../services/featureTogglePolicyService');
+    assessmentService = await import('../services/assessmentOrchestrationService');
+    ({ PATTERN_CATALOG } = await import('../services/coursePlannerService'));
   });
 
   const devconDelegationBrief: ProjectBriefInput = {
@@ -131,7 +136,7 @@ describe('Project Learning Orchestration Flow', () => {
   it('should resolve toggles based on scope', () => {
     const scope = intakeService.intakeProjectBrief(devconDelegationBrief);
     const manifest = policyService.resolveTogglePolicy(scope);
-    
+
     const adapterToggle = manifest.toggles.find(t => t.key === 'pattern.adapter');
     expect(adapterToggle?.enabled).toBe(false);
 


### PR DESCRIPTION
## Why
CI job `backend-microservice-build-and-test` intermittently fails with:
```
SqliteError: duplicate column name: claimed_at
  at initDb  src/db/initDb.ts:397
```
Seen on main run [27840546319](https://github.com/JohnAndrewBalbarosa/NeoTerritory/actions/runs/27840546319) (commit `e9218ba1`, which only touched frontend — it just exposed a pre-existing race). Later main runs went green, confirming it's **flaky**, not a hard break.

## Root cause
`projectLearningOrchestration.test.ts` and `coursePlannerService.test.ts` **statically import** services that transitively load `../db/database`, instantiating the `better-sqlite3` singleton against the **default `database.sqlite`** at module-load time — **before** `beforeAll` sets `DB_PATH` to a temp file. vitest runs test files in **parallel forks**, so two forks open the same default DB, both run `initDb()`, and both race to `ALTER TABLE users ADD COLUMN claimed_at` → the loser throws.

## Fix (test-isolation only — no production code changed)
Mirror the existing correct pattern in `assessmentScopeRoute.test.ts`:
- Set `process.env.DB_PATH` to a **unique** temp file inside `beforeAll`, then **dynamically `await import()`** the DB-touching services so `database.ts` initializes against the temp path.
- Pure-type imports (`ProjectBriefInput`) stay static via `import type`.
- `vi.mock`/`vi.hoisted` stay top-level (hoisted) and still intercept the later dynamic import.
- Unique sqlite filename per test file as an extra anti-collision guard.

## Test plan
- [x] `npm run test:unit` (Codebase/Backend) — **green across 3 consecutive runs** (74 tests)
- [x] `npm run typecheck` — clean
- [x] No production code touched (only the two test files)

> FYI @JohnAndrewBalbarosa — touches backend tests in the project-learning area; flagging in case Miryl wants a glance, but it's test-only and low-risk.