### PR TITLE
feat(backend): Bloom-level progression measure (pre vs post highest-correct level)

### DIFF
--- a/Codebase/Backend/src/__tests__/bloomProgression.test.ts
+++ b/Codebase/Backend/src/__tests__/bloomProgression.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import http from 'http';
+import jwt from 'jsonwebtoken';
+import type { Database } from 'better-sqlite3';
+
+// Isolate from production seed files (mirrors assessmentScopeRoute.test.ts).
+vi.mock('../db/_testSeed/devconUsers', () => ({
+  seedDevconUsers: () => {},
+  ensureTestFolders: () => {},
+}));
+
+// ─── Unit tests: pure computeBloomProgression ────────────────────────────────
+
+import { computeBloomProgression, BLOOM_RANK } from '../routes/learning';
+
+describe('BLOOM_RANK map', () => {
+  it('has correct ranks for all 6 levels', () => {
+    expect(BLOOM_RANK['remembering']).toBe(1);
+    expect(BLOOM_RANK['understanding']).toBe(2);
+    expect(BLOOM_RANK['applying']).toBe(3);
+    expect(BLOOM_RANK['analyzing']).toBe(4);
+    expect(BLOOM_RANK['evaluating']).toBe(5);
+    expect(BLOOM_RANK['creating']).toBe(6);
+  });
+});
+
+describe('computeBloomProgression (pure unit)', () => {
+  it('returns empty when no attempts', () => {
+    expect(computeBloomProgression([], [])).toEqual([]);
+  });
+
+  it('returns empty when cycle has only a pretest (no posttest)', () => {
+    const attempts = [{ id: 1, cycle_id: 'c1', assessment_type: 'pretest' }];
+    const answers = [
+      { cycle_id: 'c1', module_id: 'mod-a', assessment_type: 'pretest', question_taxonomy: 'remembering', is_correct: 1 },
+    ];
+    expect(computeBloomProgression(attempts, answers)).toEqual([]);
+  });
+
+  it('returns empty when cycle has only a posttest (no paired pretest)', () => {
+    const attempts = [{ id: 1, cycle_id: 'c1', assessment_type: 'posttest' }];
+    const answers = [
+      { cycle_id: 'c1', module_id: 'mod-a', assessment_type: 'posttest', question_taxonomy: 'applying', is_correct: 1 },
+    ];
+    expect(computeBloomProgression(attempts, answers)).toEqual([]);
+  });
+
+  it('leveledUp = true when postHighest > preHighest', () => {
+    // pre correct: understanding (2), post correct: applying (3) → leveled up
+    const attempts = [
+      { id: 1, cycle_id: 'c1', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c1', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c1', module_id: 'mod-a', assessment_type: 'pretest', question_taxonomy: 'understanding', is_correct: 1 },
+      { cycle_id: 'c1', module_id: 'mod-a', assessment_type: 'posttest', question_taxonomy: 'applying', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result).toHaveLength(1);
+    expect(result[0].moduleId).toBe('mod-a');
+    expect(result[0].cycleId).toBe('c1');
+    expect(result[0].preHighest).toEqual({ name: 'understanding', rank: 2 });
+    expect(result[0].postHighest).toEqual({ name: 'applying', rank: 3 });
+    expect(result[0].leveledUp).toBe(true);
+  });
+
+  it('leveledUp = false when postHighest <= preHighest (same level)', () => {
+    const attempts = [
+      { id: 1, cycle_id: 'c2', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c2', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c2', module_id: 'mod-b', assessment_type: 'pretest', question_taxonomy: 'applying', is_correct: 1 },
+      { cycle_id: 'c2', module_id: 'mod-b', assessment_type: 'posttest', question_taxonomy: 'applying', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result).toHaveLength(1);
+    expect(result[0].leveledUp).toBe(false);
+  });
+
+  it('leveledUp = false when postHighest < preHighest (regression)', () => {
+    const attempts = [
+      { id: 1, cycle_id: 'c3', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c3', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c3', module_id: 'mod-c', assessment_type: 'pretest', question_taxonomy: 'analyzing', is_correct: 1 },
+      { cycle_id: 'c3', module_id: 'mod-c', assessment_type: 'posttest', question_taxonomy: 'remembering', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result[0].leveledUp).toBe(false);
+  });
+
+  it('ignores answers with is_correct != 1', () => {
+    // Pre has only incorrect answers; post has a correct one.
+    const attempts = [
+      { id: 1, cycle_id: 'c4', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c4', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c4', module_id: 'mod-d', assessment_type: 'pretest', question_taxonomy: 'creating', is_correct: 0 },
+      { cycle_id: 'c4', module_id: 'mod-d', assessment_type: 'pretest', question_taxonomy: 'creating', is_correct: null },
+      { cycle_id: 'c4', module_id: 'mod-d', assessment_type: 'posttest', question_taxonomy: 'remembering', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result).toHaveLength(1);
+    // preHighest = null (no correct pre answers), postHighest = remembering
+    expect(result[0].preHighest).toBeNull();
+    expect(result[0].postHighest).toEqual({ name: 'remembering', rank: 1 });
+    // leveledUp: post rank (1) > pre rank (0) → true
+    expect(result[0].leveledUp).toBe(true);
+  });
+
+  it('ignores answers with unknown taxonomy', () => {
+    const attempts = [
+      { id: 1, cycle_id: 'c5', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c5', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c5', module_id: 'mod-e', assessment_type: 'pretest', question_taxonomy: 'unknown-level', is_correct: 1 },
+      { cycle_id: 'c5', module_id: 'mod-e', assessment_type: 'posttest', question_taxonomy: null, is_correct: 1 },
+    ];
+    // Both sides have no valid taxonomy → omitted
+    const result = computeBloomProgression(attempts, answers);
+    expect(result).toHaveLength(0);
+  });
+
+  it('picks highest rank within a side (multiple correct answers)', () => {
+    const attempts = [
+      { id: 1, cycle_id: 'c6', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c6', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c6', module_id: 'mod-f', assessment_type: 'pretest', question_taxonomy: 'remembering', is_correct: 1 },
+      { cycle_id: 'c6', module_id: 'mod-f', assessment_type: 'pretest', question_taxonomy: 'understanding', is_correct: 1 },
+      { cycle_id: 'c6', module_id: 'mod-f', assessment_type: 'posttest', question_taxonomy: 'analyzing', is_correct: 1 },
+      { cycle_id: 'c6', module_id: 'mod-f', assessment_type: 'posttest', question_taxonomy: 'applying', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result[0].preHighest).toEqual({ name: 'understanding', rank: 2 });
+    expect(result[0].postHighest).toEqual({ name: 'analyzing', rank: 4 });
+    expect(result[0].leveledUp).toBe(true);
+  });
+
+  it('handles two independent modules in the same cycle', () => {
+    const attempts = [
+      { id: 1, cycle_id: 'c7', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c7', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      // mod-x: leveled up
+      { cycle_id: 'c7', module_id: 'mod-x', assessment_type: 'pretest', question_taxonomy: 'understanding', is_correct: 1 },
+      { cycle_id: 'c7', module_id: 'mod-x', assessment_type: 'posttest', question_taxonomy: 'applying', is_correct: 1 },
+      // mod-y: no rise
+      { cycle_id: 'c7', module_id: 'mod-y', assessment_type: 'pretest', question_taxonomy: 'analyzing', is_correct: 1 },
+      { cycle_id: 'c7', module_id: 'mod-y', assessment_type: 'posttest', question_taxonomy: 'remembering', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result).toHaveLength(2);
+    const x = result.find((r) => r.moduleId === 'mod-x')!;
+    const y = result.find((r) => r.moduleId === 'mod-y')!;
+    expect(x.leveledUp).toBe(true);
+    expect(y.leveledUp).toBe(false);
+  });
+});
+
+// ─── Integration test: GET /api/learning/bloom-progression via HTTP ──────────
+
+describe('GET /api/learning/bloom-progression (HTTP, isolated DB)', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neoterritory-bloom-'));
+  const dbPath = path.join(tmpRoot, 'bloom.sqlite');
+  let server: http.Server | undefined;
+  let baseUrl = '';
+  let db: Database;
+  let token = '';
+
+  beforeAll(async () => {
+    process.env.DB_PATH = dbPath;
+    process.env.JWT_SECRET = 'test-bloom-secret';
+
+    db = (await import('../db/database')).default;
+    const { initDb } = await import('../db/initDb');
+    const { default: learningRoutes } = await import('../routes/learning');
+    initDb();
+
+    // Create a test user.
+    const userInfo = db
+      .prepare(`INSERT INTO users (username, email, password_hash, role, created_at) VALUES (?, ?, ?, ?, datetime('now'))`)
+      .run('bloom-learner', 'bloom-learner@example.com', 'hash', 'user');
+    const userId = Number(userInfo.lastInsertRowid);
+
+    token = jwt.sign(
+      { id: userId, username: 'bloom-learner', email: 'bloom-learner@example.com', role: 'user' },
+      process.env.JWT_SECRET as string,
+    );
+
+    // ── Fixture: cycle-A ─────────────────────────────────────────────────────
+    // Module "pattern-singleton": pre highest correct = understanding (2),
+    //   post highest correct = applying (3) → leveledUp = true
+    // Module "pattern-observer": pre highest correct = analyzing (4),
+    //   post highest correct = remembering (1) → leveledUp = false (regression)
+    const cycleId = 'cycle-bloom-a';
+
+    const insAttempt = db.prepare(
+      `INSERT INTO learning_assessment_attempts (user_id, assessment_type, question_count, cycle_id, created_at)
+       VALUES (?, ?, ?, ?, datetime('now'))`,
+    );
+    const preAttempt = insAttempt.run(userId, 'pretest', 4, cycleId);
+    const preAttemptId = Number(preAttempt.lastInsertRowid);
+    const postAttempt = insAttempt.run(userId, 'posttest', 4, cycleId);
+    const postAttemptId = Number(postAttempt.lastInsertRowid);
+
+    const insAnswer = db.prepare(
+      `INSERT INTO learning_assessment_answers
+         (attempt_id, user_id, assessment_type, assessment_index, module_id,
+          question_index, selected_index, question_taxonomy, question_kind, is_correct, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+    );
+
+    // pattern-singleton pre answers
+    insAnswer.run(preAttemptId, userId, 'pretest', 0, 'pattern-singleton', 0, 1, 'remembering', 'theoretical', 1);
+    insAnswer.run(preAttemptId, userId, 'pretest', 1, 'pattern-singleton', 1, 0, 'understanding', 'theoretical', 1); // highest pre
+    insAnswer.run(preAttemptId, userId, 'pretest', 2, 'pattern-singleton', 2, 2, 'applying', 'theoretical', 0); // wrong → excluded
+
+    // pattern-singleton post answers
+    insAnswer.run(postAttemptId, userId, 'posttest', 0, 'pattern-singleton', 0, 0, 'understanding', 'theoretical', 1);
+    insAnswer.run(postAttemptId, userId, 'posttest', 1, 'pattern-singleton', 1, 1, 'applying', 'theoretical', 1); // highest post
+
+    // pattern-observer pre answers
+    insAnswer.run(preAttemptId, userId, 'pretest', 3, 'pattern-observer', 0, 3, 'analyzing', 'theoretical', 1); // highest pre
+
+    // pattern-observer post answers
+    insAnswer.run(postAttemptId, userId, 'posttest', 2, 'pattern-observer', 0, 0, 'remembering', 'theoretical', 1); // lower post
+
+    // Start the Express app on a random port.
+    const app = express();
+    app.use(express.json());
+    app.use('/api/learning', learningRoutes);
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, '127.0.0.1', () => {
+        const a = server?.address();
+        if (!a || typeof a === 'string') throw new Error('failed to bind test server');
+        baseUrl = `http://127.0.0.1:${a.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    if (server) {
+      const s = server;
+      await new Promise<void>((r) => s.close(() => r()));
+    }
+    db.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('requires authentication', async () => {
+    const res = await fetch(`${baseUrl}/api/learning/bloom-progression`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns progression array with correct shape', async () => {
+    const res = await fetch(`${baseUrl}/api/learning/bloom-progression`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { progression: Array<{
+      moduleId: string;
+      cycleId: string;
+      preHighest: { name: string; rank: number } | null;
+      postHighest: { name: string; rank: number } | null;
+      leveledUp: boolean;
+    }> };
+    expect(Array.isArray(body.progression)).toBe(true);
+    expect(body.progression).toHaveLength(2);
+  });
+
+  it('pattern-singleton: leveledUp = true (understanding → applying)', async () => {
+    const res = await fetch(`${baseUrl}/api/learning/bloom-progression`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = (await res.json()) as { progression: Array<{ moduleId: string; preHighest: { name: string; rank: number } | null; postHighest: { name: string; rank: number } | null; leveledUp: boolean }> };
+    const entry = body.progression.find((e) => e.moduleId === 'pattern-singleton');
+    expect(entry).toBeDefined();
+    expect(entry!.preHighest).toEqual({ name: 'understanding', rank: 2 });
+    expect(entry!.postHighest).toEqual({ name: 'applying', rank: 3 });
+    expect(entry!.leveledUp).toBe(true);
+  });
+
+  it('pattern-observer: leveledUp = false (analyzing → remembering)', async () => {
+    const res = await fetch(`${baseUrl}/api/learning/bloom-progression`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = (await res.json()) as { progression: Array<{ moduleId: string; preHighest: { name: string; rank: number } | null; postHighest: { name: string; rank: number } | null; leveledUp: boolean }> };
+    const entry = body.progression.find((e) => e.moduleId === 'pattern-observer');
+    expect(entry).toBeDefined();
+    expect(entry!.preHighest).toEqual({ name: 'analyzing', rank: 4 });
+    expect(entry!.postHighest).toEqual({ name: 'remembering', rank: 1 });
+    expect(entry!.leveledUp).toBe(false);
+  });
+
+  it('incorrect answers (is_correct=0) do not raise the highest rank', async () => {
+    // pattern-singleton pre had an "applying" answer that was WRONG (is_correct=0).
+    // The reported pre highest must be "understanding" (rank 2), not "applying" (rank 3).
+    const res = await fetch(`${baseUrl}/api/learning/bloom-progression`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = (await res.json()) as { progression: Array<{ moduleId: string; preHighest: { name: string; rank: number } | null }> };
+    const entry = body.progression.find((e) => e.moduleId === 'pattern-singleton');
+    expect(entry!.preHighest?.rank).toBe(2); // NOT 3 (wrong answer excluded)
+  });
+});

--- a/Codebase/Backend/src/db/initDb.ts
+++ b/Codebase/Backend/src/db/initDb.ts
@@ -777,6 +777,13 @@ export function initDb(): void {
   }
   db.prepare(`CREATE INDEX IF NOT EXISTS idx_learning_assessment_answers_attempt_qid
     ON learning_assessment_answers(attempt_id, question_id)`).run();
+  // Bloom-level progression (additive, nullable). NULL = correctness unknown
+  // (legacy rows never had server-side grading). 1 = correct, 0 = incorrect.
+  try {
+    db.prepare(`ALTER TABLE learning_assessment_answers ADD COLUMN is_correct INTEGER`).run();
+  } catch {
+    /* column already exists */
+  }
 
   db.prepare(`CREATE TABLE IF NOT EXISTS learning_modules (
     module_id TEXT PRIMARY KEY,

--- a/Codebase/Backend/src/routes/learning.ts
+++ b/Codebase/Backend/src/routes/learning.ts
@@ -105,6 +105,9 @@ interface SanitizedAssessmentAnswer {
   responseText: string;
   questionTaxonomy: string;
   questionKind: 'theoretical' | 'practical';
+  // Bloom-level progression: server-persisted correctness flag. Null = unknown
+  // (legacy / client did not supply). 1 = correct, 0 = incorrect.
+  isCorrect: 1 | 0 | null;
 }
 
 function sanitizeAssessmentType(raw: unknown): AssessmentType | null {
@@ -142,6 +145,13 @@ function sanitizeAssessmentAnswers(input: unknown): SanitizedAssessmentAnswer[] 
       continue;
     }
 
+    // isCorrect: true/1 → 1, false/0 → 0, absent/null/undefined → null (unknown).
+    const rawIsCorrect = r.isCorrect;
+    const isCorrect: 1 | 0 | null =
+      rawIsCorrect === true || rawIsCorrect === 1 ? 1
+      : rawIsCorrect === false || rawIsCorrect === 0 ? 0
+      : null;
+
     out.push({
       moduleId,
       questionIndex,
@@ -150,6 +160,7 @@ function sanitizeAssessmentAnswers(input: unknown): SanitizedAssessmentAnswer[] 
       responseText,
       questionTaxonomy,
       questionKind,
+      isCorrect,
     });
     if (out.length >= 50) break;
   }
@@ -724,8 +735,8 @@ router.put('/assessments', jwtAuth, (req: Request, res: Response, next: NextFunc
 
     const insertAnswer = db.prepare(`
       INSERT INTO learning_assessment_answers
-        (attempt_id, user_id, session_id, assessment_type, assessment_index, module_id, question_index, question_id, selected_index, response_text, question_taxonomy, question_kind, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+        (attempt_id, user_id, session_id, assessment_type, assessment_index, module_id, question_index, question_id, selected_index, response_text, question_taxonomy, question_kind, is_correct, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
     `);
     const tx = db.transaction((rows: SanitizedAssessmentAnswer[]) => {
       rows.forEach((answer, assessmentIndex) => {
@@ -742,6 +753,7 @@ router.put('/assessments', jwtAuth, (req: Request, res: Response, next: NextFunc
           answer.responseText || null,
           answer.questionTaxonomy || null,
           answer.questionKind,
+          answer.isCorrect ?? null,
         );
       });
     });
@@ -850,6 +862,195 @@ router.patch('/bulk', jwtAuth, (req: Request, res: Response, next: NextFunction)
       res.status(400).json({ error: err.message });
       return;
     }
+    next(err);
+  }
+});
+
+// ── Bloom-level progression ─────────────────────────────────────────────────
+// GET /api/learning/bloom-progression (jwtAuth)
+//
+// Per module: highest Bloom rank among CORRECT answers (is_correct = 1) for
+// the most recent cycle that has BOTH a pretest AND a posttest attempt.
+// Rank map: remembering=1, understanding=2, applying=3, analyzing=4,
+//           evaluating=5, creating=6. Unknown/missing taxonomy → excluded.
+// leveledUp = postHighest.rank > preHighest.rank (nulls treated as rank 0).
+// Modules with no correct answers on either side are omitted.
+
+export const BLOOM_RANK: Readonly<Record<string, number>> = {
+  remembering: 1,
+  understanding: 2,
+  applying: 3,
+  analyzing: 4,
+  evaluating: 5,
+  creating: 6,
+};
+
+export interface BloomLevel {
+  name: string;
+  rank: number;
+}
+
+export interface BloomProgressionEntry {
+  moduleId: string;
+  cycleId: string;
+  preHighest: BloomLevel | null;
+  postHighest: BloomLevel | null;
+  leveledUp: boolean;
+}
+
+interface ProgressionAnswerRow {
+  cycle_id: string;
+  module_id: string;
+  assessment_type: string;
+  question_taxonomy: string | null;
+  is_correct: number | null;
+}
+
+interface ProgressionAttemptRow {
+  id: number;
+  cycle_id: string;
+  assessment_type: string;
+}
+
+/**
+ * Pure computation: given attempt rows and answer rows (already filtered to
+ * is_correct = 1), return the Bloom progression per module.
+ * Exported for unit testing without HTTP.
+ */
+export function computeBloomProgression(
+  attempts: ReadonlyArray<ProgressionAttemptRow>,
+  answers: ReadonlyArray<ProgressionAnswerRow>,
+): BloomProgressionEntry[] {
+  // Build a set of cycle_ids that have BOTH a pretest AND a posttest attempt.
+  const cyclePreIds = new Set<string>();
+  const cyclePostIds = new Set<string>();
+  for (const a of attempts) {
+    if (!a.cycle_id) continue;
+    if (a.assessment_type === 'pretest') cyclePreIds.add(a.cycle_id);
+    if (a.assessment_type === 'posttest' || a.assessment_type === 'posttest2') cyclePostIds.add(a.cycle_id);
+  }
+  const validCycleIds = new Set<string>();
+  for (const cid of cyclePreIds) {
+    if (cyclePostIds.has(cid)) validCycleIds.add(cid);
+  }
+
+  if (validCycleIds.size === 0) return [];
+
+  // Map attempt id → { cycle_id, assessment_type } for fast lookup.
+  const attemptMap = new Map<number, { cycleId: string; assessmentType: string }>();
+  for (const a of attempts) {
+    if (a.cycle_id && validCycleIds.has(a.cycle_id)) {
+      attemptMap.set(a.id, { cycleId: a.cycle_id, assessmentType: a.assessment_type });
+    }
+  }
+
+  // For each (cycleId, moduleId, pre/post), track the highest Bloom rank seen.
+  // key = `${cycleId}::${moduleId}::pre` or `...::post`
+  const highestRank = new Map<string, number>();
+
+  for (const ans of answers) {
+    if (ans.is_correct !== 1) continue;
+    if (!ans.cycle_id || !validCycleIds.has(ans.cycle_id)) continue;
+    const taxonomy = (ans.question_taxonomy ?? '').toLowerCase().trim();
+    const rank = BLOOM_RANK[taxonomy];
+    if (!rank) continue; // unknown taxonomy → skip
+
+    const side =
+      ans.assessment_type === 'pretest' ? 'pre'
+      : ans.assessment_type === 'posttest' || ans.assessment_type === 'posttest2' ? 'post'
+      : null;
+    if (!side) continue;
+
+    const key = `${ans.cycle_id}::${ans.module_id}::${side}`;
+    const current = highestRank.get(key) ?? 0;
+    if (rank > current) highestRank.set(key, rank);
+  }
+
+  // For each (cycleId, moduleId) pair, pick the most recent cycle that has a
+  // valid entry, then build the output. We group all module ids touched.
+  // Strategy: collect all (cycleId, moduleId) combos, then for each moduleId
+  // keep the cycle where the combined pre+post data is most recent.
+  // "most recent" = highest cycle_id lexicographically among valid cycles
+  // (cycle ids are UUID-ish or timestamp-ish strings; for determinism we sort
+  // valid cycle ids and pick the last one per module).
+
+  // Collect all (cycleId, moduleId) that have at least one side with a rank.
+  const moduleToLatestCycle = new Map<string, string>();
+
+  // Sort valid cycle ids so "most recent" = last in sorted order.
+  const sortedCycles = Array.from(validCycleIds).sort();
+
+  for (const cycleId of sortedCycles) {
+    // Find all module ids that have any rank entry for this cycle.
+    const modulesInCycle = new Set<string>();
+    for (const [key] of highestRank) {
+      if (key.startsWith(`${cycleId}::`)) {
+        const parts = key.split('::');
+        if (parts.length === 3) modulesInCycle.add(parts[1]);
+      }
+    }
+    for (const moduleId of modulesInCycle) {
+      // Overwrite so later (more recent) cycle wins.
+      moduleToLatestCycle.set(moduleId, cycleId);
+    }
+  }
+
+  const results: BloomProgressionEntry[] = [];
+  for (const [moduleId, cycleId] of moduleToLatestCycle) {
+    const preRank = highestRank.get(`${cycleId}::${moduleId}::pre`) ?? 0;
+    const postRank = highestRank.get(`${cycleId}::${moduleId}::post`) ?? 0;
+
+    // Omit if neither side had any correct answer with a known taxonomy.
+    if (preRank === 0 && postRank === 0) continue;
+
+    const preHighest: BloomLevel | null = preRank > 0
+      ? { name: Object.keys(BLOOM_RANK).find((k) => BLOOM_RANK[k] === preRank)!, rank: preRank }
+      : null;
+    const postHighest: BloomLevel | null = postRank > 0
+      ? { name: Object.keys(BLOOM_RANK).find((k) => BLOOM_RANK[k] === postRank)!, rank: postRank }
+      : null;
+
+    results.push({
+      moduleId,
+      cycleId,
+      preHighest,
+      postHighest,
+      leveledUp: (postRank) > (preRank),
+    });
+  }
+
+  return results;
+}
+
+router.get('/bloom-progression', jwtAuth, (req: Request, res: Response, next: NextFunction): void => {
+  try {
+    if (!req.user?.id) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    // Fetch all attempts for this user that have a cycle_id (formal assessments).
+    const attempts = db.prepare(`
+      SELECT id, cycle_id, assessment_type
+      FROM learning_assessment_attempts
+      WHERE user_id = ? AND cycle_id IS NOT NULL
+      ORDER BY created_at ASC, id ASC
+    `).all(req.user.id) as ProgressionAttemptRow[];
+
+    // Fetch all answers for this user that are marked correct and have a
+    // cycle_id (joined via attempt). NULL is_correct = unknown = excluded.
+    const answers = db.prepare(`
+      SELECT a.cycle_id, ans.module_id, ans.assessment_type,
+             ans.question_taxonomy, ans.is_correct
+      FROM learning_assessment_answers ans
+      JOIN learning_assessment_attempts a ON ans.attempt_id = a.id
+      WHERE ans.user_id = ? AND a.cycle_id IS NOT NULL AND ans.is_correct = 1
+      ORDER BY ans.created_at ASC, ans.id ASC
+    `).all(req.user.id) as ProgressionAnswerRow[];
+
+    const progression = computeBloomProgression(attempts, answers);
+    res.json({ progression });
+  } catch (err) {
     next(err);
   }
 });


### PR DESCRIPTION
Phase 1 (backend) of the Bloom-progression feature. Per module, measures whether a learner **leveled up in Bloom's taxonomy**: the highest level they answered **correctly** rose from pre-test to post-test.

## What
- **Migration**: nullable `is_correct INTEGER` on `learning_assessment_answers` (idempotent ALTER; legacy rows NULL = unknown). The backend was a raw store with no correctness; the client now supplies per-answer correctness at submit.
- **PUT /api/learning/assessments**: accepts optional per-answer `isCorrect` (true/1/false/0/null), stores it. Fully backward-compatible.
- **GET /api/learning/bloom-progression** (jwtAuth): pairs pre/post by `cycle_id`, computes per module the highest Bloom rank among **correct** answers per side (remembering=1…creating=6), returns `{ moduleId, cycleId, preHighest, postHighest, leveledUp }`. Aggregation via exported pure `computeBloomProgression` (unit-testable).

## Not in this PR (next phase)
- Client plumbing to **send** `isCorrect` at submit (the client already computes correctness for scoring).
- UI: learner growth framed **without** the word 'Bloom' + PM detailed Bloom view. (Per the agreed design: learner sees growth, no Bloom label; PM sees detail.)

## Test plan
- [x] `npm run test:unit` (Backend) — **93 pass** (16 new; DB-isolated per the PR #18 race fix)
- [x] typecheck clean
- [x] backend-only

> @JohnAndrewBalbarosa — touches the assessment area Mean girl is actively evolving (`learning.ts`, `learning_assessment_answers`). Additive + backward-compatible, but flagging for a coordinated review.