### PR TITLE
feat: Bloom-level progression — measure & show pre→post cognitive level-up (full stack)

### DIFF
--- a/Codebase/Backend/src/__tests__/bloomProgression.test.ts
+++ b/Codebase/Backend/src/__tests__/bloomProgression.test.ts
@@ -13,9 +13,25 @@ vi.mock('../db/_testSeed/devconUsers', () => ({
   ensureTestFolders: () => {},
 }));
 
-// ─── Unit tests: pure computeBloomProgression ────────────────────────────────
+// ─── Shared isolated DB + dynamic SUT load (mirrors the PR #18 pattern) ───────
+// A static import of '../routes/learning' binds the better-sqlite3 singleton to
+// the DEFAULT database.sqlite at module-load (before any DB_PATH is set), leaking
+// writes into the shared DB and racing other forks. Set a UNIQUE DB_PATH first,
+// then import the route module dynamically so db binds to this file's own temp DB.
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neoterritory-bloom-'));
+const dbPath = path.join(tmpRoot, 'bloom.sqlite');
+process.env.DB_PATH = dbPath;
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-bloom-secret';
 
-import { computeBloomProgression, BLOOM_RANK } from '../routes/learning';
+let computeBloomProgression: typeof import('../routes/learning')['computeBloomProgression'];
+let BLOOM_RANK: typeof import('../routes/learning')['BLOOM_RANK'];
+beforeAll(async () => {
+  const mod = await import('../routes/learning');
+  computeBloomProgression = mod.computeBloomProgression;
+  BLOOM_RANK = mod.BLOOM_RANK;
+});
+
+// ─── Unit tests: pure computeBloomProgression ────────────────────────────────
 
 describe('BLOOM_RANK map', () => {
   it('has correct ranks for all 6 levels', () => {
@@ -171,8 +187,7 @@ describe('computeBloomProgression (pure unit)', () => {
 // ─── Integration test: GET /api/learning/bloom-progression via HTTP ──────────
 
 describe('GET /api/learning/bloom-progression (HTTP, isolated DB)', () => {
-  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neoterritory-bloom-'));
-  const dbPath = path.join(tmpRoot, 'bloom.sqlite');
+  // Reuses the module-level isolated dbPath/tmpRoot (set above, before any db load).
   let server: http.Server | undefined;
   let baseUrl = '';
   let db: Database;

--- a/Codebase/Backend/src/__tests__/bloomProgression.test.ts
+++ b/Codebase/Backend/src/__tests__/bloomProgression.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import http from 'http';
+import jwt from 'jsonwebtoken';
+import type { Database } from 'better-sqlite3';
+
+// Isolate from production seed files (mirrors assessmentScopeRoute.test.ts).
+vi.mock('../db/_testSeed/devconUsers', () => ({
+  seedDevconUsers: () => {},
+  ensureTestFolders: () => {},
+}));
+
+// ─── Unit tests: pure computeBloomProgression ────────────────────────────────
+
+import { computeBloomProgression, BLOOM_RANK } from '../routes/learning';
+
+describe('BLOOM_RANK map', () => {
+  it('has correct ranks for all 6 levels', () => {
+    expect(BLOOM_RANK['remembering']).toBe(1);
+    expect(BLOOM_RANK['understanding']).toBe(2);
+    expect(BLOOM_RANK['applying']).toBe(3);
+    expect(BLOOM_RANK['analyzing']).toBe(4);
+    expect(BLOOM_RANK['evaluating']).toBe(5);
+    expect(BLOOM_RANK['creating']).toBe(6);
+  });
+});
+
+describe('computeBloomProgression (pure unit)', () => {
+  it('returns empty when no attempts', () => {
+    expect(computeBloomProgression([], [])).toEqual([]);
+  });
+
+  it('returns empty when cycle has only a pretest (no posttest)', () => {
+    const attempts = [{ id: 1, cycle_id: 'c1', assessment_type: 'pretest' }];
+    const answers = [
+      { cycle_id: 'c1', module_id: 'mod-a', assessment_type: 'pretest', question_taxonomy: 'remembering', is_correct: 1 },
+    ];
+    expect(computeBloomProgression(attempts, answers)).toEqual([]);
+  });
+
+  it('returns empty when cycle has only a posttest (no paired pretest)', () => {
+    const attempts = [{ id: 1, cycle_id: 'c1', assessment_type: 'posttest' }];
+    const answers = [
+      { cycle_id: 'c1', module_id: 'mod-a', assessment_type: 'posttest', question_taxonomy: 'applying', is_correct: 1 },
+    ];
+    expect(computeBloomProgression(attempts, answers)).toEqual([]);
+  });
+
+  it('leveledUp = true when postHighest > preHighest', () => {
+    // pre correct: understanding (2), post correct: applying (3) → leveled up
+    const attempts = [
+      { id: 1, cycle_id: 'c1', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c1', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c1', module_id: 'mod-a', assessment_type: 'pretest', question_taxonomy: 'understanding', is_correct: 1 },
+      { cycle_id: 'c1', module_id: 'mod-a', assessment_type: 'posttest', question_taxonomy: 'applying', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result).toHaveLength(1);
+    expect(result[0].moduleId).toBe('mod-a');
+    expect(result[0].cycleId).toBe('c1');
+    expect(result[0].preHighest).toEqual({ name: 'understanding', rank: 2 });
+    expect(result[0].postHighest).toEqual({ name: 'applying', rank: 3 });
+    expect(result[0].leveledUp).toBe(true);
+  });
+
+  it('leveledUp = false when postHighest <= preHighest (same level)', () => {
+    const attempts = [
+      { id: 1, cycle_id: 'c2', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c2', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c2', module_id: 'mod-b', assessment_type: 'pretest', question_taxonomy: 'applying', is_correct: 1 },
+      { cycle_id: 'c2', module_id: 'mod-b', assessment_type: 'posttest', question_taxonomy: 'applying', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result).toHaveLength(1);
+    expect(result[0].leveledUp).toBe(false);
+  });
+
+  it('leveledUp = false when postHighest < preHighest (regression)', () => {
+    const attempts = [
+      { id: 1, cycle_id: 'c3', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c3', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c3', module_id: 'mod-c', assessment_type: 'pretest', question_taxonomy: 'analyzing', is_correct: 1 },
+      { cycle_id: 'c3', module_id: 'mod-c', assessment_type: 'posttest', question_taxonomy: 'remembering', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result[0].leveledUp).toBe(false);
+  });
+
+  it('ignores answers with is_correct != 1', () => {
+    // Pre has only incorrect answers; post has a correct one.
+    const attempts = [
+      { id: 1, cycle_id: 'c4', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c4', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c4', module_id: 'mod-d', assessment_type: 'pretest', question_taxonomy: 'creating', is_correct: 0 },
+      { cycle_id: 'c4', module_id: 'mod-d', assessment_type: 'pretest', question_taxonomy: 'creating', is_correct: null },
+      { cycle_id: 'c4', module_id: 'mod-d', assessment_type: 'posttest', question_taxonomy: 'remembering', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result).toHaveLength(1);
+    // preHighest = null (no correct pre answers), postHighest = remembering
+    expect(result[0].preHighest).toBeNull();
+    expect(result[0].postHighest).toEqual({ name: 'remembering', rank: 1 });
+    // leveledUp: post rank (1) > pre rank (0) → true
+    expect(result[0].leveledUp).toBe(true);
+  });
+
+  it('ignores answers with unknown taxonomy', () => {
+    const attempts = [
+      { id: 1, cycle_id: 'c5', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c5', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c5', module_id: 'mod-e', assessment_type: 'pretest', question_taxonomy: 'unknown-level', is_correct: 1 },
+      { cycle_id: 'c5', module_id: 'mod-e', assessment_type: 'posttest', question_taxonomy: null, is_correct: 1 },
+    ];
+    // Both sides have no valid taxonomy → omitted
+    const result = computeBloomProgression(attempts, answers);
+    expect(result).toHaveLength(0);
+  });
+
+  it('picks highest rank within a side (multiple correct answers)', () => {
+    const attempts = [
+      { id: 1, cycle_id: 'c6', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c6', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      { cycle_id: 'c6', module_id: 'mod-f', assessment_type: 'pretest', question_taxonomy: 'remembering', is_correct: 1 },
+      { cycle_id: 'c6', module_id: 'mod-f', assessment_type: 'pretest', question_taxonomy: 'understanding', is_correct: 1 },
+      { cycle_id: 'c6', module_id: 'mod-f', assessment_type: 'posttest', question_taxonomy: 'analyzing', is_correct: 1 },
+      { cycle_id: 'c6', module_id: 'mod-f', assessment_type: 'posttest', question_taxonomy: 'applying', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result[0].preHighest).toEqual({ name: 'understanding', rank: 2 });
+    expect(result[0].postHighest).toEqual({ name: 'analyzing', rank: 4 });
+    expect(result[0].leveledUp).toBe(true);
+  });
+
+  it('handles two independent modules in the same cycle', () => {
+    const attempts = [
+      { id: 1, cycle_id: 'c7', assessment_type: 'pretest' },
+      { id: 2, cycle_id: 'c7', assessment_type: 'posttest' },
+    ];
+    const answers = [
+      // mod-x: leveled up
+      { cycle_id: 'c7', module_id: 'mod-x', assessment_type: 'pretest', question_taxonomy: 'understanding', is_correct: 1 },
+      { cycle_id: 'c7', module_id: 'mod-x', assessment_type: 'posttest', question_taxonomy: 'applying', is_correct: 1 },
+      // mod-y: no rise
+      { cycle_id: 'c7', module_id: 'mod-y', assessment_type: 'pretest', question_taxonomy: 'analyzing', is_correct: 1 },
+      { cycle_id: 'c7', module_id: 'mod-y', assessment_type: 'posttest', question_taxonomy: 'remembering', is_correct: 1 },
+    ];
+    const result = computeBloomProgression(attempts, answers);
+    expect(result).toHaveLength(2);
+    const x = result.find((r) => r.moduleId === 'mod-x')!;
+    const y = result.find((r) => r.moduleId === 'mod-y')!;
+    expect(x.leveledUp).toBe(true);
+    expect(y.leveledUp).toBe(false);
+  });
+});
+
+// ─── Integration test: GET /api/learning/bloom-progression via HTTP ──────────
+
+describe('GET /api/learning/bloom-progression (HTTP, isolated DB)', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neoterritory-bloom-'));
+  const dbPath = path.join(tmpRoot, 'bloom.sqlite');
+  let server: http.Server | undefined;
+  let baseUrl = '';
+  let db: Database;
+  let token = '';
+
+  beforeAll(async () => {
+    process.env.DB_PATH = dbPath;
+    process.env.JWT_SECRET = 'test-bloom-secret';
+
+    db = (await import('../db/database')).default;
+    const { initDb } = await import('../db/initDb');
+    const { default: learningRoutes } = await import('../routes/learning');
+    initDb();
+
+    // Create a test user.
+    const userInfo = db
+      .prepare(`INSERT INTO users (username, email, password_hash, role, created_at) VALUES (?, ?, ?, ?, datetime('now'))`)
+      .run('bloom-learner', 'bloom-learner@example.com', 'hash', 'user');
+    const userId = Number(userInfo.lastInsertRowid);
+
+    token = jwt.sign(
+      { id: userId, username: 'bloom-learner', email: 'bloom-learner@example.com', role: 'user' },
+      process.env.JWT_SECRET as string,
+    );
+
+    // ── Fixture: cycle-A ─────────────────────────────────────────────────────
+    // Module "pattern-singleton": pre highest correct = understanding (2),
+    //   post highest correct = applying (3) → leveledUp = true
+    // Module "pattern-observer": pre highest correct = analyzing (4),
+    //   post highest correct = remembering (1) → leveledUp = false (regression)
+    const cycleId = 'cycle-bloom-a';
+
+    const insAttempt = db.prepare(
+      `INSERT INTO learning_assessment_attempts (user_id, assessment_type, question_count, cycle_id, created_at)
+       VALUES (?, ?, ?, ?, datetime('now'))`,
+    );
+    const preAttempt = insAttempt.run(userId, 'pretest', 4, cycleId);
+    const preAttemptId = Number(preAttempt.lastInsertRowid);
+    const postAttempt = insAttempt.run(userId, 'posttest', 4, cycleId);
+    const postAttemptId = Number(postAttempt.lastInsertRowid);
+
+    const insAnswer = db.prepare(
+      `INSERT INTO learning_assessment_answers
+         (attempt_id, user_id, assessment_type, assessment_index, module_id,
+          question_index, selected_index, question_taxonomy, question_kind, is_correct, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+    );
+
+    // pattern-singleton pre answers
+    insAnswer.run(preAttemptId, userId, 'pretest', 0, 'pattern-singleton', 0, 1, 'remembering', 'theoretical', 1);
+    insAnswer.run(preAttemptId, userId, 'pretest', 1, 'pattern-singleton', 1, 0, 'understanding', 'theoretical', 1); // highest pre
+    insAnswer.run(preAttemptId, userId, 'pretest', 2, 'pattern-singleton', 2, 2, 'applying', 'theoretical', 0); // wrong → excluded
+
+    // pattern-singleton post answers
+    insAnswer.run(postAttemptId, userId, 'posttest', 0, 'pattern-singleton', 0, 0, 'understanding', 'theoretical', 1);
+    insAnswer.run(postAttemptId, userId, 'posttest', 1, 'pattern-singleton', 1, 1, 'applying', 'theoretical', 1); // highest post
+
+    // pattern-observer pre answers
+    insAnswer.run(preAttemptId, userId, 'pretest', 3, 'pattern-observer', 0, 3, 'analyzing', 'theoretical', 1); // highest pre
+
+    // pattern-observer post answers
+    insAnswer.run(postAttemptId, userId, 'posttest', 2, 'pattern-observer', 0, 0, 'remembering', 'theoretical', 1); // lower post
+
+    // Start the Express app on a random port.
+    const app = express();
+    app.use(express.json());
+    app.use('/api/learning', learningRoutes);
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, '127.0.0.1', () => {
+        const a = server?.address();
+        if (!a || typeof a === 'string') throw new Error('failed to bind test server');
+        baseUrl = `http://127.0.0.1:${a.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    if (server) {
+      const s = server;
+      await new Promise<void>((r) => s.close(() => r()));
+    }
+    db.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('requires authentication', async () => {
+    const res = await fetch(`${baseUrl}/api/learning/bloom-progression`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns progression array with correct shape', async () => {
+    const res = await fetch(`${baseUrl}/api/learning/bloom-progression`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { progression: Array<{
+      moduleId: string;
+      cycleId: string;
+      preHighest: { name: string; rank: number } | null;
+      postHighest: { name: string; rank: number } | null;
+      leveledUp: boolean;
+    }> };
+    expect(Array.isArray(body.progression)).toBe(true);
+    expect(body.progression).toHaveLength(2);
+  });
+
+  it('pattern-singleton: leveledUp = true (understanding → applying)', async () => {
+    const res = await fetch(`${baseUrl}/api/learning/bloom-progression`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = (await res.json()) as { progression: Array<{ moduleId: string; preHighest: { name: string; rank: number } | null; postHighest: { name: string; rank: number } | null; leveledUp: boolean }> };
+    const entry = body.progression.find((e) => e.moduleId === 'pattern-singleton');
+    expect(entry).toBeDefined();
+    expect(entry!.preHighest).toEqual({ name: 'understanding', rank: 2 });
+    expect(entry!.postHighest).toEqual({ name: 'applying', rank: 3 });
+    expect(entry!.leveledUp).toBe(true);
+  });
+
+  it('pattern-observer: leveledUp = false (analyzing → remembering)', async () => {
+    const res = await fetch(`${baseUrl}/api/learning/bloom-progression`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = (await res.json()) as { progression: Array<{ moduleId: string; preHighest: { name: string; rank: number } | null; postHighest: { name: string; rank: number } | null; leveledUp: boolean }> };
+    const entry = body.progression.find((e) => e.moduleId === 'pattern-observer');
+    expect(entry).toBeDefined();
+    expect(entry!.preHighest).toEqual({ name: 'analyzing', rank: 4 });
+    expect(entry!.postHighest).toEqual({ name: 'remembering', rank: 1 });
+    expect(entry!.leveledUp).toBe(false);
+  });
+
+  it('incorrect answers (is_correct=0) do not raise the highest rank', async () => {
+    // pattern-singleton pre had an "applying" answer that was WRONG (is_correct=0).
+    // The reported pre highest must be "understanding" (rank 2), not "applying" (rank 3).
+    const res = await fetch(`${baseUrl}/api/learning/bloom-progression`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = (await res.json()) as { progression: Array<{ moduleId: string; preHighest: { name: string; rank: number } | null }> };
+    const entry = body.progression.find((e) => e.moduleId === 'pattern-singleton');
+    expect(entry!.preHighest?.rank).toBe(2); // NOT 3 (wrong answer excluded)
+  });
+});

--- a/Codebase/Backend/src/db/initDb.ts
+++ b/Codebase/Backend/src/db/initDb.ts
@@ -791,6 +791,13 @@ export function initDb(): void {
   }
   db.prepare(`CREATE INDEX IF NOT EXISTS idx_learning_assessment_answers_attempt_qid
     ON learning_assessment_answers(attempt_id, question_id)`).run();
+  // Bloom-level progression (additive, nullable). NULL = correctness unknown
+  // (legacy rows never had server-side grading). 1 = correct, 0 = incorrect.
+  try {
+    db.prepare(`ALTER TABLE learning_assessment_answers ADD COLUMN is_correct INTEGER`).run();
+  } catch {
+    /* column already exists */
+  }
 
   db.prepare(`CREATE TABLE IF NOT EXISTS learning_modules (
     module_id TEXT PRIMARY KEY,

--- a/Codebase/Backend/src/routes/admin.ts
+++ b/Codebase/Backend/src/routes/admin.ts
@@ -40,6 +40,7 @@ import {
 import { aggregateQuestionResults, type RawResultRow } from '../services/learningQuestionStats';
 import { generateCoursePlan } from '../services/coursePlannerService';
 import { probeProviderReachability, type Provider } from '../services/aiDocumentationService';
+import { computeBloomProgression, type ProgressionAttemptRow, type ProgressionAnswerRow } from './learning';
 
 // Pre-hashed bcrypt of the log-delete password. Override via LOG_DELETE_HASH env var.
 const LOG_DELETE_HASH = process.env.LOG_DELETE_HASH
@@ -3083,6 +3084,38 @@ router.delete('/pattern-groups/:id', (req: Request, res: Response, next: NextFun
     bumpCatalogEpoch();
     res.json({ removed: info.changes });
   } catch (err) { next(err); }
+});
+
+// GET /api/admin/learning/bloom-progression?userId=<id>
+// Per-learner Bloom-level progression for the PM/instructor view. Reuses the
+// learner route's pure computeBloomProgression on the TARGET user's stored,
+// client-graded (is_correct = 1) formal assessment answers, paired by cycle_id.
+router.get('/learning/bloom-progression', (req: Request, res: Response, next: NextFunction): void => {
+  try {
+    const userId = typeof req.query.userId === 'string' ? Number(req.query.userId) : NaN;
+    if (!Number.isInteger(userId) || userId <= 0) {
+      res.status(400).json({ error: 'userId required' });
+      return;
+    }
+    const attempts = db.prepare(`
+      SELECT id, cycle_id, assessment_type
+      FROM learning_assessment_attempts
+      WHERE user_id = ? AND cycle_id IS NOT NULL
+      ORDER BY created_at ASC, id ASC
+    `).all(userId) as ProgressionAttemptRow[];
+    const answers = db.prepare(`
+      SELECT a.cycle_id, ans.module_id, ans.assessment_type,
+             ans.question_taxonomy, ans.is_correct
+      FROM learning_assessment_answers ans
+      JOIN learning_assessment_attempts a ON ans.attempt_id = a.id
+      WHERE ans.user_id = ? AND a.cycle_id IS NOT NULL AND ans.is_correct = 1
+      ORDER BY ans.created_at ASC, ans.id ASC
+    `).all(userId) as ProgressionAnswerRow[];
+    const progression = computeBloomProgression(attempts, answers);
+    res.json({ progression });
+  } catch (err) {
+    next(err);
+  }
 });
 
 export default router;

--- a/Codebase/Backend/src/routes/learning.ts
+++ b/Codebase/Backend/src/routes/learning.ts
@@ -105,6 +105,9 @@ interface SanitizedAssessmentAnswer {
   responseText: string;
   questionTaxonomy: string;
   questionKind: 'theoretical' | 'practical';
+  // Bloom-level progression: server-persisted correctness flag. Null = unknown
+  // (legacy / client did not supply). 1 = correct, 0 = incorrect.
+  isCorrect: 1 | 0 | null;
 }
 
 function sanitizeAssessmentType(raw: unknown): AssessmentType | null {
@@ -142,6 +145,13 @@ function sanitizeAssessmentAnswers(input: unknown): SanitizedAssessmentAnswer[] 
       continue;
     }
 
+    // isCorrect: true/1 → 1, false/0 → 0, absent/null/undefined → null (unknown).
+    const rawIsCorrect = r.isCorrect;
+    const isCorrect: 1 | 0 | null =
+      rawIsCorrect === true || rawIsCorrect === 1 ? 1
+      : rawIsCorrect === false || rawIsCorrect === 0 ? 0
+      : null;
+
     out.push({
       moduleId,
       questionIndex,
@@ -150,6 +160,7 @@ function sanitizeAssessmentAnswers(input: unknown): SanitizedAssessmentAnswer[] 
       responseText,
       questionTaxonomy,
       questionKind,
+      isCorrect,
     });
     if (out.length >= 50) break;
   }
@@ -736,8 +747,8 @@ router.put('/assessments', jwtAuth, (req: Request, res: Response, next: NextFunc
 
     const insertAnswer = db.prepare(`
       INSERT INTO learning_assessment_answers
-        (attempt_id, user_id, session_id, assessment_type, assessment_index, module_id, question_index, question_id, selected_index, response_text, question_taxonomy, question_kind, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+        (attempt_id, user_id, session_id, assessment_type, assessment_index, module_id, question_index, question_id, selected_index, response_text, question_taxonomy, question_kind, is_correct, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
     `);
     const tx = db.transaction((rows: SanitizedAssessmentAnswer[]) => {
       rows.forEach((answer, assessmentIndex) => {
@@ -754,6 +765,7 @@ router.put('/assessments', jwtAuth, (req: Request, res: Response, next: NextFunc
           answer.responseText || null,
           answer.questionTaxonomy || null,
           answer.questionKind,
+          answer.isCorrect ?? null,
         );
       });
     });
@@ -862,6 +874,195 @@ router.patch('/bulk', jwtAuth, (req: Request, res: Response, next: NextFunction)
       res.status(400).json({ error: err.message });
       return;
     }
+    next(err);
+  }
+});
+
+// ── Bloom-level progression ─────────────────────────────────────────────────
+// GET /api/learning/bloom-progression (jwtAuth)
+//
+// Per module: highest Bloom rank among CORRECT answers (is_correct = 1) for
+// the most recent cycle that has BOTH a pretest AND a posttest attempt.
+// Rank map: remembering=1, understanding=2, applying=3, analyzing=4,
+//           evaluating=5, creating=6. Unknown/missing taxonomy → excluded.
+// leveledUp = postHighest.rank > preHighest.rank (nulls treated as rank 0).
+// Modules with no correct answers on either side are omitted.
+
+export const BLOOM_RANK: Readonly<Record<string, number>> = {
+  remembering: 1,
+  understanding: 2,
+  applying: 3,
+  analyzing: 4,
+  evaluating: 5,
+  creating: 6,
+};
+
+export interface BloomLevel {
+  name: string;
+  rank: number;
+}
+
+export interface BloomProgressionEntry {
+  moduleId: string;
+  cycleId: string;
+  preHighest: BloomLevel | null;
+  postHighest: BloomLevel | null;
+  leveledUp: boolean;
+}
+
+interface ProgressionAnswerRow {
+  cycle_id: string;
+  module_id: string;
+  assessment_type: string;
+  question_taxonomy: string | null;
+  is_correct: number | null;
+}
+
+interface ProgressionAttemptRow {
+  id: number;
+  cycle_id: string;
+  assessment_type: string;
+}
+
+/**
+ * Pure computation: given attempt rows and answer rows (already filtered to
+ * is_correct = 1), return the Bloom progression per module.
+ * Exported for unit testing without HTTP.
+ */
+export function computeBloomProgression(
+  attempts: ReadonlyArray<ProgressionAttemptRow>,
+  answers: ReadonlyArray<ProgressionAnswerRow>,
+): BloomProgressionEntry[] {
+  // Build a set of cycle_ids that have BOTH a pretest AND a posttest attempt.
+  const cyclePreIds = new Set<string>();
+  const cyclePostIds = new Set<string>();
+  for (const a of attempts) {
+    if (!a.cycle_id) continue;
+    if (a.assessment_type === 'pretest') cyclePreIds.add(a.cycle_id);
+    if (a.assessment_type === 'posttest' || a.assessment_type === 'posttest2') cyclePostIds.add(a.cycle_id);
+  }
+  const validCycleIds = new Set<string>();
+  for (const cid of cyclePreIds) {
+    if (cyclePostIds.has(cid)) validCycleIds.add(cid);
+  }
+
+  if (validCycleIds.size === 0) return [];
+
+  // Map attempt id → { cycle_id, assessment_type } for fast lookup.
+  const attemptMap = new Map<number, { cycleId: string; assessmentType: string }>();
+  for (const a of attempts) {
+    if (a.cycle_id && validCycleIds.has(a.cycle_id)) {
+      attemptMap.set(a.id, { cycleId: a.cycle_id, assessmentType: a.assessment_type });
+    }
+  }
+
+  // For each (cycleId, moduleId, pre/post), track the highest Bloom rank seen.
+  // key = `${cycleId}::${moduleId}::pre` or `...::post`
+  const highestRank = new Map<string, number>();
+
+  for (const ans of answers) {
+    if (ans.is_correct !== 1) continue;
+    if (!ans.cycle_id || !validCycleIds.has(ans.cycle_id)) continue;
+    const taxonomy = (ans.question_taxonomy ?? '').toLowerCase().trim();
+    const rank = BLOOM_RANK[taxonomy];
+    if (!rank) continue; // unknown taxonomy → skip
+
+    const side =
+      ans.assessment_type === 'pretest' ? 'pre'
+      : ans.assessment_type === 'posttest' || ans.assessment_type === 'posttest2' ? 'post'
+      : null;
+    if (!side) continue;
+
+    const key = `${ans.cycle_id}::${ans.module_id}::${side}`;
+    const current = highestRank.get(key) ?? 0;
+    if (rank > current) highestRank.set(key, rank);
+  }
+
+  // For each (cycleId, moduleId) pair, pick the most recent cycle that has a
+  // valid entry, then build the output. We group all module ids touched.
+  // Strategy: collect all (cycleId, moduleId) combos, then for each moduleId
+  // keep the cycle where the combined pre+post data is most recent.
+  // "most recent" = highest cycle_id lexicographically among valid cycles
+  // (cycle ids are UUID-ish or timestamp-ish strings; for determinism we sort
+  // valid cycle ids and pick the last one per module).
+
+  // Collect all (cycleId, moduleId) that have at least one side with a rank.
+  const moduleToLatestCycle = new Map<string, string>();
+
+  // Sort valid cycle ids so "most recent" = last in sorted order.
+  const sortedCycles = Array.from(validCycleIds).sort();
+
+  for (const cycleId of sortedCycles) {
+    // Find all module ids that have any rank entry for this cycle.
+    const modulesInCycle = new Set<string>();
+    for (const [key] of highestRank) {
+      if (key.startsWith(`${cycleId}::`)) {
+        const parts = key.split('::');
+        if (parts.length === 3) modulesInCycle.add(parts[1]);
+      }
+    }
+    for (const moduleId of modulesInCycle) {
+      // Overwrite so later (more recent) cycle wins.
+      moduleToLatestCycle.set(moduleId, cycleId);
+    }
+  }
+
+  const results: BloomProgressionEntry[] = [];
+  for (const [moduleId, cycleId] of moduleToLatestCycle) {
+    const preRank = highestRank.get(`${cycleId}::${moduleId}::pre`) ?? 0;
+    const postRank = highestRank.get(`${cycleId}::${moduleId}::post`) ?? 0;
+
+    // Omit if neither side had any correct answer with a known taxonomy.
+    if (preRank === 0 && postRank === 0) continue;
+
+    const preHighest: BloomLevel | null = preRank > 0
+      ? { name: Object.keys(BLOOM_RANK).find((k) => BLOOM_RANK[k] === preRank)!, rank: preRank }
+      : null;
+    const postHighest: BloomLevel | null = postRank > 0
+      ? { name: Object.keys(BLOOM_RANK).find((k) => BLOOM_RANK[k] === postRank)!, rank: postRank }
+      : null;
+
+    results.push({
+      moduleId,
+      cycleId,
+      preHighest,
+      postHighest,
+      leveledUp: (postRank) > (preRank),
+    });
+  }
+
+  return results;
+}
+
+router.get('/bloom-progression', jwtAuth, (req: Request, res: Response, next: NextFunction): void => {
+  try {
+    if (!req.user?.id) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    // Fetch all attempts for this user that have a cycle_id (formal assessments).
+    const attempts = db.prepare(`
+      SELECT id, cycle_id, assessment_type
+      FROM learning_assessment_attempts
+      WHERE user_id = ? AND cycle_id IS NOT NULL
+      ORDER BY created_at ASC, id ASC
+    `).all(req.user.id) as ProgressionAttemptRow[];
+
+    // Fetch all answers for this user that are marked correct and have a
+    // cycle_id (joined via attempt). NULL is_correct = unknown = excluded.
+    const answers = db.prepare(`
+      SELECT a.cycle_id, ans.module_id, ans.assessment_type,
+             ans.question_taxonomy, ans.is_correct
+      FROM learning_assessment_answers ans
+      JOIN learning_assessment_attempts a ON ans.attempt_id = a.id
+      WHERE ans.user_id = ? AND a.cycle_id IS NOT NULL AND ans.is_correct = 1
+      ORDER BY ans.created_at ASC, ans.id ASC
+    `).all(req.user.id) as ProgressionAnswerRow[];
+
+    const progression = computeBloomProgression(attempts, answers);
+    res.json({ progression });
+  } catch (err) {
     next(err);
   }
 });

--- a/Codebase/Backend/src/routes/learning.ts
+++ b/Codebase/Backend/src/routes/learning.ts
@@ -910,7 +910,7 @@ export interface BloomProgressionEntry {
   leveledUp: boolean;
 }
 
-interface ProgressionAnswerRow {
+export interface ProgressionAnswerRow {
   cycle_id: string;
   module_id: string;
   assessment_type: string;
@@ -918,7 +918,7 @@ interface ProgressionAnswerRow {
   is_correct: number | null;
 }
 
-interface ProgressionAttemptRow {
+export interface ProgressionAttemptRow {
   id: number;
   cycle_id: string;
   assessment_type: string;

--- a/Codebase/Frontend/src/admin/components/InstructorStudents.tsx
+++ b/Codebase/Frontend/src/admin/components/InstructorStudents.tsx
@@ -1,11 +1,14 @@
-import { useMemo, useState } from 'react';
-import type { AdminLearningRaw } from '../../types/api';
+import { useEffect, useMemo, useState } from 'react';
+import type { AdminLearningRaw, BloomProgressionEntry } from '../../types/api';
 import {
   perStudentRows,
   studentDrilldown,
   type InstructorStudentRow,
 } from '../logic/learningAggregate';
 import { downloadCsv, downloadJson } from '../logic/toCsv';
+import { fetchAdminBloomProgression } from '../../api/client';
+import { isAuthError } from '../lib/silenceAuthErrors';
+import { useLearningModules } from '../../data/useLearningModules';
 
 // Students sub-view of the Instructor tab (D91). Per-student rollup table
 // (scores, attempts, pass/fail, improvement) computed client-side from the raw
@@ -40,12 +43,47 @@ interface InstructorStudentsProps {
 export default function InstructorStudents({ raw }: InstructorStudentsProps): JSX.Element {
   const [sort, setSort] = useState<SortKey>('improvement');
   const [openUserId, setOpenUserId] = useState<number | null>(null);
+  const [bloomProgression, setBloomProgression] = useState<BloomProgressionEntry[] | null>(null);
+  const [bloomLoading, setBloomLoading] = useState(false);
+  const { modules } = useLearningModules();
 
   const rows = useMemo(() => sortRows(perStudentRows(raw), sort), [raw, sort]);
   const drill = useMemo(
     () => (openUserId === null ? [] : studentDrilldown(raw, openUserId)),
     [raw, openUserId],
   );
+
+  // Fetch Bloom progression whenever a student row is opened.
+  useEffect(() => {
+    if (openUserId === null) {
+      setBloomProgression(null);
+      return;
+    }
+    let cancelled = false;
+    setBloomLoading(true);
+    setBloomProgression(null);
+    fetchAdminBloomProgression(openUserId)
+      .then((data) => {
+        if (!cancelled) {
+          setBloomProgression(data.progression);
+          setBloomLoading(false);
+        }
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (!isAuthError(e)) {
+          // Non-fatal: the rest of the drilldown still renders.
+          setBloomProgression([]);
+        }
+        setBloomLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [openUserId]);
+
+  // Build a map from moduleId to module title for display.
+  const moduleById = useMemo(() => new Map(modules.map((m) => [m.id, m])), [modules]);
 
   function onDownloadCsv(): void {
     const headers = [
@@ -181,6 +219,58 @@ export default function InstructorStudents({ raw }: InstructorStudentsProps): JS
               Close
             </button>
           </header>
+
+          {/* Bloom-level progression per module (pre vs. post cycle) */}
+          <div style={{ marginBottom: 20 }}>
+            <h4 style={{ margin: '0 0 8px', fontSize: 14, color: 'var(--color-text-muted, rgba(255,255,255,0.6))', textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+              Bloom Progression (Pre → Post)
+            </h4>
+            {bloomLoading ? (
+              <div className="empty-state" style={{ padding: '10px 0' }}>Loading Bloom progression…</div>
+            ) : bloomProgression === null || bloomProgression.length === 0 ? (
+              <div className="empty-state" style={{ padding: '10px 0' }}>
+                No paired pre/post assessments found for this learner.
+              </div>
+            ) : (
+              <div className="instructor-table-wrap">
+                <table className="admin-table">
+                  <thead>
+                    <tr>
+                      <th>Module</th>
+                      <th>Pre-test highest level</th>
+                      <th>Post-test highest level</th>
+                      <th>Outcome</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {bloomProgression.map((entry) => (
+                      <tr key={`${entry.cycleId}:${entry.moduleId}`}>
+                        <td>
+                          <small>{moduleById.get(entry.moduleId)?.title ?? entry.moduleId}</small>
+                        </td>
+                        <td>
+                          {entry.preHighest
+                            ? `${entry.preHighest.name} (L${entry.preHighest.rank})`
+                            : <span style={{ color: 'var(--color-text-muted, rgba(255,255,255,0.45))' }}>—</span>}
+                        </td>
+                        <td>
+                          {entry.postHighest
+                            ? `${entry.postHighest.name} (L${entry.postHighest.rank})`
+                            : <span style={{ color: 'var(--color-text-muted, rgba(255,255,255,0.45))' }}>—</span>}
+                        </td>
+                        <td>
+                          {entry.leveledUp
+                            ? <span className="pill pill-green">Leveled up</span>
+                            : <span className="pill">No change</span>}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
           {drill.length === 0 ? (
             <div className="empty-state">No answered questions for this student yet.</div>
           ) : (

--- a/Codebase/Frontend/src/api/client.ts
+++ b/Codebase/Frontend/src/api/client.ts
@@ -7,6 +7,7 @@ import {
   SurveySummary, ComplexityData, F1Metrics,
   LearningModuleDTO, LearningModulesResponse, AdminLearningModule, AdminLearningModulesResponse,
   LearningAssessmentAnswerInput, LearningAssessmentType, LearningAssessmentsResponse,
+  BloomProgressionResponse,
   AdminFeatureReleasePlan, AdminFeatureReleasePlannerFlag, AdminCoursePlan
 } from '../types/api';
 
@@ -349,6 +350,10 @@ export async function saveLearningAssessment(payload: {
     method: 'PUT',
     body: JSON.stringify(payload),
   });
+}
+
+export async function fetchBloomProgression(): Promise<BloomProgressionResponse> {
+  return apiFetch<BloomProgressionResponse>('/api/learning/bloom-progression');
 }
 
 export interface ActivePlanResponse {

--- a/Codebase/Frontend/src/api/client.ts
+++ b/Codebase/Frontend/src/api/client.ts
@@ -356,6 +356,12 @@ export async function fetchBloomProgression(): Promise<BloomProgressionResponse>
   return apiFetch<BloomProgressionResponse>('/api/learning/bloom-progression');
 }
 
+export async function fetchAdminBloomProgression(userId: number): Promise<BloomProgressionResponse> {
+  return apiFetch<BloomProgressionResponse>(
+    `/api/admin/learning/bloom-progression?userId=${encodeURIComponent(userId)}`,
+  );
+}
+
 export interface ActivePlanResponse {
   plan: {
     id: string;

--- a/Codebase/Frontend/src/components/learn/InternDashboard.tsx
+++ b/Codebase/Frontend/src/components/learn/InternDashboard.tsx
@@ -5,6 +5,7 @@ import { useLearningModules } from '../../data/useLearningModules';
 import {
   fetchLearningAssessments,
   fetchLearningProgress,
+  fetchBloomProgression,
   type LearningProgress,
 } from '../../api/client';
 import { useAppStore } from '../../store/appState';
@@ -14,7 +15,7 @@ import {
   resolvePostTestCycleId,
   pairedLearningGain,
 } from '../../logic/postTestEligibility';
-import type { LearningAssessmentsResponse } from '../../types/api';
+import type { LearningAssessmentsResponse, BloomProgressionEntry } from '../../types/api';
 
 function readUnlockAllOverride(): boolean {
   if (typeof window === 'undefined') return false;
@@ -35,6 +36,7 @@ export default function InternDashboard(): JSX.Element {
   const { modules, loaded } = useLearningModules();
   const [progress, setProgress] = useState<LearningProgress | null>(null);
   const [assessments, setAssessments] = useState<LearningAssessmentsResponse | null>(null);
+  const [bloomProgression, setBloomProgression] = useState<BloomProgressionEntry[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -61,11 +63,16 @@ export default function InternDashboard(): JSX.Element {
       };
     }
 
-    Promise.all([fetchLearningProgress(), fetchLearningAssessments()])
-      .then(([progressData, assessmentData]) => {
+    Promise.all([
+      fetchLearningProgress(),
+      fetchLearningAssessments(),
+      fetchBloomProgression().catch(() => null),
+    ])
+      .then(([progressData, assessmentData, bloomData]) => {
         if (!cancelled) {
           setProgress(progressData);
           setAssessments(assessmentData);
+          setBloomProgression(bloomData?.progression ?? null);
         }
       })
       .catch((e: unknown) => {
@@ -191,6 +198,21 @@ export default function InternDashboard(): JSX.Element {
   }).filter((row) => row.total > 0);
 
   const recentModules = modules.slice(Math.max(0, modules.length - 6));
+
+  // Learner growth data: modules where the post-test showed improvement over
+  // the pre-test. Only shown when at least one module has leveledUp === true.
+  // NOTE: No Bloom terminology is exposed to the learner — this section uses
+  // plain language about "deepening understanding" only.
+  const leveledUpModules = useMemo(() => {
+    if (!bloomProgression) return [];
+    const leveledUp = bloomProgression.filter((entry) => entry.leveledUp);
+    // Resolve module titles from the loaded modules list.
+    const moduleById = new Map(modules.map((m) => [m.id, m]));
+    return leveledUp.map((entry) => ({
+      moduleId: entry.moduleId,
+      title: moduleById.get(entry.moduleId)?.title ?? entry.moduleId,
+    }));
+  }, [bloomProgression, modules]);
 
   return (
     <main style={styles.shell}>
@@ -334,6 +356,26 @@ export default function InternDashboard(): JSX.Element {
           </p>
         </article>
       </section>
+
+      {leveledUpModules.length > 0 && (
+        <section style={styles.growthSection}>
+          <article style={styles.growthCard}>
+            <p style={styles.growthLabel}>Your Progress This Cycle</p>
+            <p style={styles.growthHeading}>
+              You deepened your understanding in {leveledUpModules.length}{' '}
+              module{leveledUpModules.length === 1 ? '' : 's'} after the post-test.
+            </p>
+            <ul style={styles.growthList}>
+              {leveledUpModules.map((m) => (
+                <li key={m.moduleId} style={styles.growthItem}>
+                  <span style={styles.growthDot} aria-hidden="true" />
+                  {m.title}
+                </li>
+              ))}
+            </ul>
+          </article>
+        </section>
+      )}
 
       <section style={styles.stack}>
         <article style={styles.panel}>
@@ -650,6 +692,50 @@ const styles: Record<string, CSSProperties> = {
   moduleTitle: {
     margin: '4px 0 0',
     fontWeight: 600,
+  },
+  growthSection: {
+    maxWidth: 1180,
+    margin: '16px auto 0',
+  },
+  growthCard: {
+    padding: 20,
+    borderRadius: 20,
+    border: '1px solid rgba(166,255,0,0.22)',
+    background: 'linear-gradient(145deg, rgba(166,255,0,0.07), rgba(12,18,30,0.9))',
+  },
+  growthLabel: {
+    margin: 0,
+    color: '#a6ff00',
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.1em',
+    fontSize: 12,
+  },
+  growthHeading: {
+    margin: '8px 0 12px',
+    fontSize: 18,
+    fontWeight: 600,
+    color: '#f4f7fb',
+  },
+  growthList: {
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    display: 'grid',
+    gap: 8,
+  },
+  growthItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    color: 'rgba(244,247,251,0.88)',
+    fontSize: 14,
+  },
+  growthDot: {
+    width: 7,
+    height: 7,
+    borderRadius: '50%',
+    background: '#a6ff00',
+    flexShrink: 0,
   },
   moduleFlags: {
     display: 'grid',

--- a/Codebase/Frontend/src/components/learn/InternDashboard.tsx
+++ b/Codebase/Frontend/src/components/learn/InternDashboard.tsx
@@ -5,7 +5,6 @@ import { useLearningModules } from '../../data/useLearningModules';
 import {
   fetchLearningAssessments,
   fetchLearningProgress,
-  fetchBloomProgression,
   type LearningProgress,
 } from '../../api/client';
 import { useAppStore } from '../../store/appState';
@@ -15,7 +14,7 @@ import {
   resolvePostTestCycleId,
   pairedLearningGain,
 } from '../../logic/postTestEligibility';
-import type { LearningAssessmentsResponse, BloomProgressionEntry } from '../../types/api';
+import type { LearningAssessmentsResponse } from '../../types/api';
 
 function readUnlockAllOverride(): boolean {
   if (typeof window === 'undefined') return false;
@@ -36,7 +35,6 @@ export default function InternDashboard(): JSX.Element {
   const { modules, loaded } = useLearningModules();
   const [progress, setProgress] = useState<LearningProgress | null>(null);
   const [assessments, setAssessments] = useState<LearningAssessmentsResponse | null>(null);
-  const [bloomProgression, setBloomProgression] = useState<BloomProgressionEntry[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -66,13 +64,11 @@ export default function InternDashboard(): JSX.Element {
     Promise.all([
       fetchLearningProgress(),
       fetchLearningAssessments(),
-      fetchBloomProgression().catch(() => null),
     ])
-      .then(([progressData, assessmentData, bloomData]) => {
+      .then(([progressData, assessmentData]) => {
         if (!cancelled) {
           setProgress(progressData);
           setAssessments(assessmentData);
-          setBloomProgression(bloomData?.progression ?? null);
         }
       })
       .catch((e: unknown) => {
@@ -198,21 +194,6 @@ export default function InternDashboard(): JSX.Element {
   }).filter((row) => row.total > 0);
 
   const recentModules = modules.slice(Math.max(0, modules.length - 6));
-
-  // Learner growth data: modules where the post-test showed improvement over
-  // the pre-test. Only shown when at least one module has leveledUp === true.
-  // NOTE: No Bloom terminology is exposed to the learner — this section uses
-  // plain language about "deepening understanding" only.
-  const leveledUpModules = useMemo(() => {
-    if (!bloomProgression) return [];
-    const leveledUp = bloomProgression.filter((entry) => entry.leveledUp);
-    // Resolve module titles from the loaded modules list.
-    const moduleById = new Map(modules.map((m) => [m.id, m]));
-    return leveledUp.map((entry) => ({
-      moduleId: entry.moduleId,
-      title: moduleById.get(entry.moduleId)?.title ?? entry.moduleId,
-    }));
-  }, [bloomProgression, modules]);
 
   return (
     <main style={styles.shell}>
@@ -356,26 +337,6 @@ export default function InternDashboard(): JSX.Element {
           </p>
         </article>
       </section>
-
-      {leveledUpModules.length > 0 && (
-        <section style={styles.growthSection}>
-          <article style={styles.growthCard}>
-            <p style={styles.growthLabel}>Your Progress This Cycle</p>
-            <p style={styles.growthHeading}>
-              You deepened your understanding in {leveledUpModules.length}{' '}
-              module{leveledUpModules.length === 1 ? '' : 's'} after the post-test.
-            </p>
-            <ul style={styles.growthList}>
-              {leveledUpModules.map((m) => (
-                <li key={m.moduleId} style={styles.growthItem}>
-                  <span style={styles.growthDot} aria-hidden="true" />
-                  {m.title}
-                </li>
-              ))}
-            </ul>
-          </article>
-        </section>
-      )}
 
       <section style={styles.stack}>
         <article style={styles.panel}>
@@ -692,50 +653,6 @@ const styles: Record<string, CSSProperties> = {
   moduleTitle: {
     margin: '4px 0 0',
     fontWeight: 600,
-  },
-  growthSection: {
-    maxWidth: 1180,
-    margin: '16px auto 0',
-  },
-  growthCard: {
-    padding: 20,
-    borderRadius: 20,
-    border: '1px solid rgba(166,255,0,0.22)',
-    background: 'linear-gradient(145deg, rgba(166,255,0,0.07), rgba(12,18,30,0.9))',
-  },
-  growthLabel: {
-    margin: 0,
-    color: '#a6ff00',
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.1em',
-    fontSize: 12,
-  },
-  growthHeading: {
-    margin: '8px 0 12px',
-    fontSize: 18,
-    fontWeight: 600,
-    color: '#f4f7fb',
-  },
-  growthList: {
-    listStyle: 'none',
-    margin: 0,
-    padding: 0,
-    display: 'grid',
-    gap: 8,
-  },
-  growthItem: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 10,
-    color: 'rgba(244,247,251,0.88)',
-    fontSize: 14,
-  },
-  growthDot: {
-    width: 7,
-    height: 7,
-    borderRadius: '50%',
-    background: '#a6ff00',
-    flexShrink: 0,
   },
   moduleFlags: {
     display: 'grid',

--- a/Codebase/Frontend/src/data/learningAssessments.ts
+++ b/Codebase/Frontend/src/data/learningAssessments.ts
@@ -133,6 +133,13 @@ export function buildLearningAssessmentAnswerInputs(
     .filter((question) => hasLearningAssessmentAnswer(question.question, answers[question.assessmentIndex]))
     .map((question) => {
       const answer = answers[question.assessmentIndex];
+      const correctness = isMcqQuestion(question.question)
+        ? typeof answer === 'number' && answer === question.question.correctIndex
+        : isIdentificationQuestion(question.question)
+          ? isAnswerCorrect(question.question, answer)
+          : isStudioQuestion(question.question)
+            ? null
+            : null;
       return {
         moduleId: question.moduleId,
         questionIndex: question.questionIndex,
@@ -141,6 +148,7 @@ export function buildLearningAssessmentAnswerInputs(
         responseText: serializeAssessmentResponse(question.question, answer),
         questionTaxonomy: question.taxonomy,
         questionKind: 'theoretical' as const,
+        isCorrect: correctness,
       };
     });
 }

--- a/Codebase/Frontend/src/types/api.ts
+++ b/Codebase/Frontend/src/types/api.ts
@@ -272,6 +272,7 @@ export interface LearningAssessmentAnswerInput {
   responseText?: string | null;
   questionTaxonomy?: BloomTaxonomy | null;
   questionKind?: 'theoretical' | 'practical';
+  isCorrect?: boolean | null;
 }
 
 export interface LearningAssessmentAttemptRaw {
@@ -307,6 +308,18 @@ export interface LearningAssessmentsResponse {
   attempts: LearningAssessmentAttemptRaw[];
   answers: LearningAssessmentAnswerRaw[];
   courseUpdatedAt?: string;
+}
+
+export interface BloomProgressionEntry {
+  moduleId: string;
+  cycleId: string;
+  preHighest: { name: string; rank: number } | null;
+  postHighest: { name: string; rank: number } | null;
+  leveledUp: boolean;
+}
+
+export interface BloomProgressionResponse {
+  progression: BloomProgressionEntry[];
 }
 
 // ── Learning CMS (D92) ────────────────────────────────────────────────────


### PR DESCRIPTION
Complete Bloom-level progression feature (backend + frontend). Per module, measures whether a learner **leveled up in Bloom's taxonomy**: the highest level they answered **correctly** rose from pre-test to post-test. **Supersedes #22** (its backend is included here, with the admin endpoint + a test-isolation fix added).

## Backend
- Migration: nullable `is_correct` on `learning_assessment_answers` (client supplies correctness at submit; legacy NULL = unknown).
- `PUT /assessments` stores per-answer `isCorrect`.
- `GET /api/learning/bloom-progression` (learner) + `GET /api/admin/learning/bloom-progression?userId=` (admin) — both reuse the pure `computeBloomProgression` (pairs pre/post by cycle, highest CORRECT Bloom rank per side, remembering=1…creating=6).
- Fixed a latent test-isolation bug (static import bound db to the default DB before DB_PATH — same class as #18).

## Frontend
- Submit now sends per-answer `isCorrect` (reuses existing `isAnswerCorrect`).
- **Learner** (InternDashboard): growth card for leveled-up modules, framed **without any Bloom terminology**.
- **PM** (InstructorStudents / In-Module Analytics): per-learner per-module pre→post highest level + 'Leveled up' indicator (Bloom shown — admin-only).

## Correctness note
The formal Form A/B answer keys live in the frontend, so correctness is supplied by the client (is_correct) rather than re-derived server-side from `theoretical_json` (which is the in-module bank, not the formal forms).

## Test plan
- [x] Backend: 93 unit tests pass (incl. isolated bloom-progression HTTP tests); typecheck clean
- [x] Frontend: 179 unit tests pass; typecheck clean
- [x] Learner UI shows no Bloom terminology

> @JohnAndrewBalbarosa — assessment area (coordinate w/ Mean girl). Rebased clean on latest main.