### PR TITLE
test(backend): raise vitest hook timeout to 30s (fix seed-heavy flakiness)

### DIFF
--- a/Codebase/Backend/vitest.config.ts
+++ b/Codebase/Backend/vitest.config.ts
@@ -11,5 +11,11 @@ export default defineConfig({
     // Each test file gets its own module instance so any module-level
     // state (e.g. env-var snapshots) does not leak across files.
     isolate: true,
+    // Seed-heavy suites (e.g. projectLearningOrchestration, coursePlannerService,
+    // adminLearningInterns) run initDb in beforeAll, which seeds ~40 learning
+    // modules. Under full-parallel load this can exceed the 10s default and flake
+    // with "Hook timed out". Raise the hook + test ceilings to absorb that.
+    hookTimeout: 30000,
+    testTimeout: 30000,
   },
 });


### PR DESCRIPTION
Pre-existing flakiness on main (NOT from any feature branch — reproduced on main directly): three seed-heavy suites (`projectLearningOrchestration`, `coursePlannerService`, `adminLearningInterns`) run `initDb` (~40 modules) in `beforeAll` and exceed the 10s default `hookTimeout` under full-parallel load, failing with 'Hook timed out in 10000ms'.

Fix: raise `hookTimeout` + `testTimeout` to 30s in `Codebase/Backend/vitest.config.ts`.

Verified: full backend suite — **85 tests pass, 0 timeouts**.